### PR TITLE
Minor updates

### DIFF
--- a/R/circular.plot.r
+++ b/R/circular.plot.r
@@ -160,14 +160,14 @@ circ.wg.plot <- function(cnv,
     colores[which(cnvcirc$segmean < log2(1 - lrr.pct)) ] <- "blue"
     colores[which(cnvcirc$segmean > log2(1 + lrr.pct)) ] <- "red"
     cnvcirc <- data.table(cnvcirc,colores)
-    cnvcirc[which(cnvcirc$segmean < log2(1/lrr.max) ),"segmean"] <- log2(1/lrr.max) 
+    cnvcirc[which(cnvcirc$segmean < log2(1/lrr.max)),"segmean"] <- log2(1/lrr.max) 
     cnvcirc[which(cnvcirc$segmean > log2(lrr.max)),"segmean"] <- log2(lrr.max)
     allcnvlist <- list()
     for(i in chrlist) allcnvlist[[i]] <- as.data.frame(cnvcirc[which(cnvcirc$chrom == i),])
     
     circos.initializeWithIdeogram(species=genome.v, chromosome.index=chrlist, plotType=c("ideogram","labels"))
-    text(0, 0,  gsub("_","\n",sample.id), cex = 1)
-    circos.genomicTrackPlotRegion(allcnvlist, bg.lwd =0.2, bg.col=rainbow(length(allcnvlist),alpha=0.1),ylim=c(-2.4,2.4), track.height=0.2, panel.fun = function(region, value, ...) {
+    text(0.8, 1,  gsub("_","\n",sample.id), cex = 1)
+    circos.genomicTrackPlotRegion(allcnvlist, bg.lwd =0.2, bg.col=rainbow(length(allcnvlist),alpha=0.1),ylim=c(log2(1/lrr.max),log2(lrr.max)), track.height=0.2, panel.fun = function(region, value, ...) {
         circos.genomicLines(region, value, col=as.character(allcnvlist[[CELL_META$sector.index]][,"colores"]), numeric.column = c(1), type="segment")
     })
     circos.genomicLink(alllinks1, alllinks2, col = alllinkcolors, border = NA)

--- a/R/gene.cnv.r
+++ b/R/gene.cnv.r
@@ -117,11 +117,11 @@ return(out)
 
 amp.del <- function(genecnv.obj, logr.cut=2){
     
-    amp_list <- apply(genecnv.obj@cnvmat, 1, function(x) names(which(x >= 2)))
+    amp_list <- apply(genecnv.obj@cnvmat, 1, function(x) names(which(x >= logr.cut)))
     amp_list <- amp_list[which(unlist(lapply(amp_list,length)) > 0)]
     amp_rank <- sort(unlist(lapply(amp_list,length)),decreasing=TRUE)
 
-    del_list <- apply(genecnv.obj@cnvmat, 1, function(x) names(which(x <= -2)))
+    del_list <- apply(genecnv.obj@cnvmat, 1, function(x) names(which(x <= -logr.cut)))
     del_list <- del_list[which(unlist(lapply(del_list,length)) > 0)]
     del_rank <- sort(unlist(lapply(del_list,length)),decreasing=TRUE)
     


### PR DESCRIPTION
Minor updates implemented for the BARD1 paper:

1) In circular.plot.r, define ylim based on lrr.max instead of hardcoded values. Also changed position of the sample label.
2) Update amp.del function (in gene.cnv.r) to use logr.cut argument instead of hardcoded values.